### PR TITLE
How-To Sync Data : use pipes instead of hooks in the plugin

### DIFF
--- a/sync-data-to-another-database/README.md
+++ b/sync-data-to-another-database/README.md
@@ -34,7 +34,7 @@ On Kuzzle, the data will be stored in the `yellow-taxi` collection of the `nyc-o
 }
 ```
 
-On Cassandra's side, we will dump the data into the `yellow_taxi` table of the `nyc_open_data` keyspace. (Note the use of `_` instead of `-` because of Cassandra's restrictions)  
+On Cassandra's side, we will synchronize the data into the `yellow_taxi` table of the `nyc_open_data` keyspace. (Note the use of `_` instead of `-` because of Cassandra's restrictions)  
 
 In Elasticseach we use the geo_point type to index our documents geographically. With Cassandra, we will have to create a [User Defined Type](https://docs.datastax.com/en/cql/3.3/cql/cql_using/useCreateUDT.html) emulating that type, and we will name it geopoint
 

--- a/sync-data-to-another-database/README.md
+++ b/sync-data-to-another-database/README.md
@@ -34,7 +34,7 @@ On Kuzzle, the data will be stored in the `yellow-taxi` collection of the `nyc-o
 }
 ```
 
-On Cassandra's side, we will synchronize the data into the `yellow_taxi` table of the `nyc_open_data` keyspace. (Note the use of `_` instead of `-` because of Cassandra's restrictions)  
+On Cassandra's side, we will store the data into the `yellow_taxi` table of the `nyc_open_data` keyspace. (Note the use of `_` instead of `-` because of Cassandra's restrictions)  
 
 In Elasticseach we use the geo_point type to index our documents geographically. With Cassandra, we will have to create a [User Defined Type](https://docs.datastax.com/en/cql/3.3/cql/cql_using/useCreateUDT.html) emulating that type, and we will name it geopoint
 

--- a/sync-data-to-another-database/README.md
+++ b/sync-data-to-another-database/README.md
@@ -11,10 +11,9 @@ Cassandra : `>= 3`
 
 Kuzzle uses Elasticsearch, which allows it to offer very good search performance on large volumes.  
 
-However, it can also be useful to dump Kuzzle data into external databases, for example if you wanted to store and analyse historical data.  
-[Cassandra](https://cassandra.apache.org/) is a distributed NoSQL database designed to handle large volumes of data.  
+However, when integrating Kuzzle into an existing infrastructure, you may want Kuzzle to also dump its data into your databases for use by your other applications.  
 
-In this How-To, we will show you how to develop a Kuzzle Plugin that synchonizes Kuzzle's data with any other database system by taking Cassandra as an example.  
+In this How-To, we will show you how to develop a Kuzzle Plugin that synchonizes Kuzzle's data with any other database system by taking [Cassandra](https://cassandra.apache.org/) as an example.  
 For this example we will use data from the NYC Yellow Taxi dataset.  
 
 ## Architecture
@@ -56,16 +55,16 @@ CREATE TABLE IF NOT EXISTS nyc_open_data.yellow_taxi (kuzzle_id text, pickup_dat
 The [Kuzzle Plugin Engine](https://docs.kuzzle.io/plugins-reference/plugins-features/) lets you extend Kuzzle's functionality by adding code modules that offer auxiliary features. These modules can:
 
   - Listen asynchronously to events
-  - Listen synchronously to events (and intercept a request)
+  - Listen synchronously to events (and pipe a request)
   - Add a controller route
   - Add a new authentication strategy
 
-We will create a plugin [listening asynchronously](https://docs.kuzzle.io/plugins-reference/plugins-features/adding-hooks/) to Document Controller events in order to report document changes in Cassandra.  
+We will create a plugin [listening synchronously](https://docs.kuzzle.io/plugins-reference/plugins-features/adding-pipes/) to Document Controller events in order to report document changes in Cassandra.  
 
-### Hook some events
+### Pipe some events
 
-The first step is to declare which [Plugin Events](https://docs.kuzzle.io/kuzzle-events/plugin-events/) we are going to hook. These hooks must be declared in the plugin constructor.  
-Each hook is associated with a plugin method that will be called when the event occurs.  
+The first step is to declare which [Plugin Events](https://docs.kuzzle.io/kuzzle-events/plugin-events/) we are going to pipe. These pipes must be declared in the plugin constructor.  
+Each pipe is associated with a plugin method that will be called when the event occurs.  
 
 At the Document Controller level, we have two main families of events:
  - actions on a document
@@ -75,7 +74,7 @@ We will intercept all of these events after the corresponding action has been ta
 
 ```js
 constructor () {
-  this.hooks = {
+  this.pipes = {
     // Event concerning a single document
     'document:afterCreate':           'hookPutDocument',
     'document:afterCreateOrReplace':  'hookPutDocument',
@@ -93,7 +92,9 @@ constructor () {
 }
 ```
 
-Each method will receive a [Request](https://github.com/kuzzleio/kuzzle-common-objects#request) object when an event occurs. Depending on the event triggered, the Request exposes a [Response](https://docs.kuzzle.io/api-documentation/kuzzle-response/) object that will contain the result of the controller's action corresponding to the event.  
+Each method will receive two parameters :
+ - a [Request](https://github.com/kuzzleio/kuzzle-common-objects#request) object when an event occurs. Depending on the event triggered, the Request exposes a [Response](https://docs.kuzzle.io/api-documentation/kuzzle-response/) object that will contain the result of the controller's action corresponding to the event.
+ - a callback that should be called when the pipe has finished processing the data. The callback take two arguments, an eventual error and the request object : `callback(error, request)`.
 
 In order to reflect the changes in Cassandra, we need to know the content of the document as well as the collection and index it is stored in.
 
@@ -180,7 +181,7 @@ createOrUpdateDocuments (documents) {
 ```
 ### Try it yourself
 
-You can use the [docker-compose.yml](docker-compose.yml) included in this How-To to test the export plugin to Cassandra.  
+You can use the [docker-compose.yml](docker-compose.yml) included in this How-To to test the synchronization plugin to Cassandra.  
 The containers are preconfigured to work with NYC Open Data's Yellow Taxi dataset.  
 
 ```bash
@@ -195,9 +196,9 @@ docker-compose exec kuzzle node /yellow_taxi/load_data.js
 docker-compose exec kuzzle node /yellow_taxi/load_data.js --max-count 10000 --batch-size 1000
 ```
 
-On a laptop with a I5-7300U CPU @ 2.60 GHz, 16GiB of RAM and a SSD it takes approximatively 2 minutes to load 1 millions of document in Kuzzle with the Cassandra export.  
+On a laptop with a I5-7300U CPU @ 2.60 GHz, 16GiB of RAM and a SSD it takes approximatively 2 minutes to load 1 millions of document in Kuzzle with the Cassandra synchronization.  
 
-We can then check that the import worked as expected:
+We can then check that the synchronization worked as expected:
 
 ```bash
 docker-compose exec kuzzle node /yellow_taxi/count_data.js

--- a/sync-data-to-another-database/docker-compose.yml
+++ b/sync-data-to-another-database/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: kuzzleio/howto-syncdata-kuzzle
     command: /custom_start.sh
     volumes:
-      - ".:/var/app/plugins/enabled/kuzzle-plugin-export-cassandra"
+      - ".:/var/app/plugins/enabled/kuzzle-plugin-sync-cassandra"
     depends_on:
       - redis
       - elasticsearch

--- a/sync-data-to-another-database/docker/kuzzle/custom_start.sh
+++ b/sync-data-to-another-database/docker/kuzzle/custom_start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-npm --prefix /var/app/plugins/enabled/kuzzle-plugin-export-cassandra install /var/app/plugins/enabled/kuzzle-plugin-export-cassandra
+npm --prefix /var/app/plugins/enabled/kuzzle-plugin-sync-cassandra install /var/app/plugins/enabled/kuzzle-plugin-sync-cassandra
 
 kuzzle start  --mappings /yellow_taxi/yellow_taxi_mapping.json

--- a/sync-data-to-another-database/lib/index.js
+++ b/sync-data-to-another-database/lib/index.js
@@ -15,7 +15,7 @@ class ExportCassandra {
       }
     };
 
-    this.hooks = {
+    this.pipes = {
       'document:afterCreate':           'hookPutDocument',
       'document:afterCreateOrReplace':  'hookPutDocument',
       'document:afterReplace':          'hookPutDocument',
@@ -40,7 +40,7 @@ class ExportCassandra {
     this.context = context;
 
     if (! this.config.cassandra.contactPoints || this.config.cassandra.contactPoints.length < 1) {
-      return Promise.reject(new this.context.errors.InternalError('[kuzzle-plugin-export-cassandra] You must provide at least one contactPoints'));
+      return Promise.reject(new this.context.errors.InternalError('[kuzzle-plugin-sync-cassandra] You must provide at least one contactPoints'));
     }
 
     this.exporter = new Exporter(this.config.cassandra, context);
@@ -50,29 +50,37 @@ class ExportCassandra {
       .catch(error => Promise.reject(error))
   }
 
-  hookPutDocument (request) {
+  hookPutDocument (request, callback) {
     const document = request.response.result;
 
     this.exporter.createOrUpdateDocuments([document])
-      .then(() => this.context.log.debug('[kuzzle-plugin-export-cassandra] Document inserted'))
+      .then(() => {
+        this.context.log.debug('[kuzzle-plugin-sync-cassandra] Document inserted');
+        callback(null, request);
+      })
       .catch(error => {
-        this.context.log.error('[kuzzle-plugin-export-cassandra] Error inserting document');
+        this.context.log.error('[kuzzle-plugin-sync-cassandra] Error inserting document');
         this.context.log.error(error);
+        callback(new this.context.errors.ExternalServiceError(`Error inserting document in cassandra: ${error.message}`), request);
       });
   }
 
-  hookPutDocuments (request) {
+  hookPutDocuments (request, callback) {
     const response = request.response;
 
     this.exporter.createOrUpdateDocuments(response.result.hits)
-      .then(() => this.context.log.debug(`[kuzzle-plugin-export-cassandra] ${response.result.hits.length} Document inserted`))
+      .then(() => {
+        this.context.log.debug(`[kuzzle-plugin-sync-cassandra] ${response.result.hits.length} Document inserted`);
+        callback(null, request);
+      })
       .catch(error => {
-        this.context.log.error('[kuzzle-plugin-export-cassandra] Error inserting document');
+        this.context.log.error('[kuzzle-plugin-sync-cassandra] Error inserting document');
         this.context.log.error(error);
+        callback(new this.context.errors.ExternalServiceError(`Error inserting document in cassandra: ${error.message}`), request);
       });
   }
 
-  hookUpdateDocument (request) {
+  hookUpdateDocument (request, callback) {
     const response = request.response;
     const document = {
       _id: response.result._id,
@@ -82,14 +90,18 @@ class ExportCassandra {
     };
 
     this.exporter.createOrUpdateDocuments([document])
-      .then(() => this.context.log.debug('[kuzzle-plugin-export-cassandra] Document updated'))
+      .then(() => {
+        this.context.log.debug('[kuzzle-plugin-sync-cassandra] Document updated');
+        callback(null, request);
+      })
       .catch(error => {
-        this.context.log.error('[kuzzle-plugin-export-cassandra] Error inserting document');
+        this.context.log.error('[kuzzle-plugin-sync-cassandra] Error inserting document');
         this.context.log.error(error);
+        callback(new this.context.errors.ExternalServiceError(`Error inserting document in cassandra: ${error.message}`), request);
       });
   }
 
-  hookUpdateDocuments (request) {
+  hookUpdateDocuments (request, callback) {
     const response = request.response;
     const documents = response.body.documents.map(({ _id, body }) => {
       return {
@@ -101,48 +113,65 @@ class ExportCassandra {
     });
 
     this.exporter.createOrUpdateDocuments(documents)
-      .then(() => this.context.log.debug(`[kuzzle-plugin-export-cassandra] ${documents.length} document updated`))
+      .then(() => {
+        this.context.log.debug(`[kuzzle-plugin-sync-cassandra] ${documents.length} document updated`);
+        callback(null, request);
+      })
       .catch(error => {
-        this.context.log.error('[kuzzle-plugin-export-cassandra] Error updating documents');
+        this.context.log.error('[kuzzle-plugin-sync-cassandra] Error updating documents');
         this.context.log.error(error);
+        callback(new this.context.errors.ExternalServiceError(`Error inserting document in cassandra: ${error.message}`), request);
       });
   }
 
-  hookDeleteDocument (request) {
+  hookDeleteDocument (request, callback) {
     const response = request.response;
 
     this.exporter.deleteDocuments({ keyspace: response.index, table: response.collection, kuzzleIds: [response.result._id] })
-      .then(() => this.context.log.debug('[kuzzle-plugin-export-cassandra] Document deleted'))
+      .then(() => {
+        this.context.log.debug('[kuzzle-plugin-sync-cassandra] Document deleted');
+        callback(null, request);
+      })
       .catch(error => {
-        this.context.log.error('[kuzzle-plugin-export-cassandra] Error deleting document');
+        this.context.log.error('[kuzzle-plugin-sync-cassandra] Error deleting document');
         this.context.log.error(error);
+        callback(new this.context.errors.ExternalServiceError(`Error deleting document in cassandra: ${error.message}`), request);
       });
   }
 
-  hookDeleteDocuments (request) {
+  hookDeleteDocuments (request, callback) {
     const response = request.response;
 
     this.exporter.deleteDocuments({ keyspace: response.index, table: response.collection, kuzzleIds: response.result.hits })
-      .then(() => this.context.log.debug(`[kuzzle-plugin-export-cassandra] ${response.result.hits.length} documents deleted`))
+      .then(() => {
+        this.context.log.debug(`[kuzzle-plugin-sync-cassandra] ${response.result.hits.length} documents deleted`);
+        callback(null, request);
+      })
       .catch(error => {
-        this.context.log.error('[kuzzle-plugin-export-cassandra] Error deleting document');
+        this.context.log.error('[kuzzle-plugin-sync-cassandra] Error deleting document');
         this.context.log.error(error);
+        callback(new this.context.errors.ExternalServiceError(`Error deleting documents in cassandra: ${error.message}`), request);
       });
   }
 
-  hookMDeleteDocuments (request) {
+  hookMDeleteDocuments (request, callback) {
     const response = request.response;
 
     this.exporter.deleteDocuments({ keyspace: response.index, table: response.collection, kuzzleIds: response.result })
-      .then(() => this.context.log.debug(`[kuzzle-plugin-export-cassandra] ${response.result.length} documents deleted`))
+      .then(() => {
+        this.context.log.debug(`[kuzzle-plugin-sync-cassandra] ${response.result.length} documents deleted`);
+        callback(null, request);
+      })
       .catch(error => {
-        this.context.log.error('[kuzzle-plugin-export-cassandra] Error deleting documents');
+        this.context.log.error('[kuzzle-plugin-sync-cassandra] Error deleting documents');
         this.context.log.error(error);
+        callback(new this.context.errors.ExternalServiceError(`Error deleting documents in cassandra: ${error.message}`), request);
       });
   }
 
-  hookError(request) {
+  hookError(request, callback) {
     this.context.log.error(request.error);
+    callback(null, request)
   }
 }
 

--- a/sync-data-to-another-database/lib/services/exporter.js
+++ b/sync-data-to-another-database/lib/services/exporter.js
@@ -25,14 +25,14 @@ class Exporter {
     return this.client
       .connect()
       .then(() => {
-        this.context.log.info('[kuzzle-plugin-export-cassandra] Cassandra client connected');
+        this.context.log.info('[kuzzle-plugin-sync-cassandra] Cassandra client connected');
         return Promise.resolve(true);
       })
       .catch(error => {
         if (this.config.retryCount <= 0) {
-          return Promise.reject(new this.context.errors.InternalError(`[kuzzle-plugin-export-cassandra] Unable to connect the client : ${error.message}`));
+          return Promise.reject(new this.context.errors.InternalError(`[kuzzle-plugin-sync-cassandra] Unable to connect the client : ${error.message}`));
         } else {
-          this.context.log.info(`[kuzzle-plugin-export-cassandra] Failed to connect to Cassandra on startup - ${error.message} - retrying in 2 sec`)
+          this.context.log.info(`[kuzzle-plugin-sync-cassandra] Failed to connect to Cassandra on startup - ${error.message} - retrying in 2 sec`)
           this.config.retryCount -= 1;
           setTimeout(() => {
             this.connectWithRetry()

--- a/sync-data-to-another-database/manifest.json
+++ b/sync-data-to-another-database/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "kuzzle-plugin-export-cassandra",
+  "name": "kuzzle-plugin-sync-cassandra",
   "version": "1.2.0",
   "threadable": false,
   "kuzzleVersion": "^1.1.x"

--- a/sync-data-to-another-database/package-lock.json
+++ b/sync-data-to-another-database/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "kuzzle-plugin-export-cassandra",
+  "name": "kuzzle-plugin-sync-cassandra",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/sync-data-to-another-database/package.json
+++ b/sync-data-to-another-database/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kuzzle-plugin-export-cassandra",
+  "name": "kuzzle-plugin-sync-cassandra",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "version": "0.0.1",
   "description": "Kuzzle plugin export Cassandra",


### PR DESCRIPTION
In our use case we want to synchronize efficiently Kuzzle with an other DBMS.   

The first approach was to use asynchronous plugin hook when documents were inserted. This can lead to differences between Kuzzle and the external database.  

The new approach is to use synchronous plugin with pipes to tell that the insertion work as expected.  