### PR TITLE
Add missing root index

### DIFF
--- a/doc/1/index.md
+++ b/doc/1/index.md
@@ -1,0 +1,7 @@
+---
+code: false
+type: root
+order: 0
+title: How-To
+description: Kuzzle How-To examples
+---

--- a/kuzzle-esp32/01-rgb-led/rgb-led.md
+++ b/kuzzle-esp32/01-rgb-led/rgb-led.md
@@ -77,7 +77,7 @@ To allow your application to communicate with Kuzzle, you need 2 components:
 
 Clone the esp-mqtt and kuzzle-esp32 components in the `components` folder to add them to your project:
 
-``` console
+```shell
 $ git submodule add https://github.com/espressif/esp-mqtt components/esp-mqtt
 $ git submodule add https://github.com/kuzzleio/kuzzle-esp32 components/kuzzle-esp32
 ```
@@ -86,7 +86,7 @@ $ git submodule add https://github.com/kuzzleio/kuzzle-esp32 components/kuzzle-e
 
 Your project folder structure should now look like this:
 
-``` console
+```shell
 $ tree -d -L 2
 .
 ├── components


### PR DESCRIPTION
# Description

The documentation fails to build because, when it tries to compute the path for the page `/404.html`, it doesn't find any entry for the / root directory.

# Other changes

* `console` is not a language supported by github flavored markdowns. Replaced it by `shell`